### PR TITLE
UPDATE: added flag --provenance=false to the npm publish command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "migrate-node-deps",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "migrate-node-deps",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "MIT",
       "bin": {
         "migrate-node-deps": "bin/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "migrate-node-deps",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "`migrate-node-deps` is a CLI tool that clones npm dependencies and their transitive dependencies to a local private registry (like Verdaccio).",
   "keywords": [
     "private",

--- a/src/publishToVerdaccio.js
+++ b/src/publishToVerdaccio.js
@@ -108,7 +108,7 @@ async function publishToVerdaccio(packageSpec, options) {
                 log(`Using tag: ${tag} for package ${packageSpec}`, verbose);
 
                 // Using --access=public to ensure scoped packages publish correctly
-                execSync(`npm publish ${tarballFile} --registry ${verdaccioRegistry} --access=public --tag ${tag}`, {
+                execSync(`npm publish ${tarballFile} --registry ${verdaccioRegistry} --access=public --tag ${tag} --provenance=false`, {
                     stdio: 'pipe',  // Capture output instead of inheriting
                     timeout: 30000  // 30 seconds timeout
                 });


### PR DESCRIPTION
This pull request includes a version update for the `migrate-node-deps` package and a modification to the `npm publish` command in the `publishToVerdaccio` function to disable provenance.

### Version update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `0.0.3` to `0.0.4`.

### Changes to `npm publish` behavior:
* [`src/publishToVerdaccio.js`](diffhunk://#diff-572dcbf2981d2eb07895d8194f14d18ba2cca230d5b6b31983bfddf453fef5b3L111-R111): Modified the `npm publish` command to include the `--provenance=false` flag, disabling provenance when publishing packages to Verdaccio.