### PR TITLE
Fix/local repository authentification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "migrate-node-deps",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "migrate-node-deps",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "MIT",
       "bin": {
         "migrate-node-deps": "bin/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "migrate-node-deps",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "`migrate-node-deps` is a CLI tool that clones npm dependencies and their transitive dependencies to a local private registry (like Verdaccio).",
   "keywords": [
     "private",


### PR DESCRIPTION
This pull request includes updates to the `migrate-node-deps` project, focusing on improving the `authenticateVerdaccio` function and incrementing the package version. The changes enhance authentication handling, improve code readability, and ensure better logging and error handling.

### Authentication Enhancements:
* Refactored the `authenticateVerdaccio` function to include detailed JSDoc comments, making the function's purpose and parameters clearer.
* Improved authentication logic by normalizing the registry URL, adding verbose logging, and handling `.npmrc` updates more robustly. This includes removing outdated auth entries before adding new ones.
* Added verification steps after both non-interactive and interactive authentication to ensure the user is successfully authenticated. [[1]](diffhunk://#diff-49ba0c85360693b8e89ae0e0428284a55db749f08f2b9993d26910def646e02fL130-R217) [[2]](diffhunk://#diff-49ba0c85360693b8e89ae0e0428284a55db749f08f2b9993d26910def646e02fL174-R241)
* Introduced a helper function for logging to streamline verbose output handling during authentication.

### Version Update:
* Updated the package version in `package.json` from `0.0.4` to `0.0.5` to reflect the new changes.