### PR TITLE
UPDATE: When main function reaches the finally() block the package wi…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "migrate-node-deps",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "migrate-node-deps",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "MIT",
       "bin": {
         "migrate-node-deps": "bin/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "migrate-node-deps",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "`migrate-node-deps` is a CLI tool that clones npm dependencies and their transitive dependencies to a local private registry (like Verdaccio).",
   "keywords": [
     "private",

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ const writeFile = promisify(fs.writeFile);
 const mkdtemp = promisify(fs.mkdtemp);
 const rm = promisify(fs.rm);
 const os = require('os');
+const { execSync } = require('child_process');
 
 const constants = require('./constants');
 const { parseArgs, authenticateVerdaccio, log } = require('./helpers');
@@ -49,6 +50,9 @@ async function main() {
             showHelp();
             return;
         }
+
+        // Store the original npm registry
+        const originalRegistry = execSync('npm config get registry', { encoding: 'utf8' }).trim();
 
         // Setup configuration from options or defaults
         const config = {
@@ -218,6 +222,10 @@ Migration operation completed:
             // Change back to original directory
             process.chdir(originalDir);
         } finally {
+            // Reset npm registry to the original one
+            execSync(`npm config set registry ${originalRegistry}`);
+            console.log(`Restored original npm registry: ${originalRegistry}`);
+
             // Clean up
             try {
                 await rm(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
This pull request introduces a version bump for the `migrate-node-deps` package and adds functionality to handle the npm registry configuration more robustly during the migration process. The main changes include storing and restoring the original npm registry and updating the package version.

### Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `0.0.5` to `0.0.6` to reflect the new changes.

### Enhancements to npm registry handling:

* [`src/main.js`](diffhunk://#diff-27653c212e1cfe533e4eb2f7d0d3f89604c9de48a09583b4cbbbcbd08a07da79R9): Added `execSync` from the `child_process` module to enable synchronous execution of shell commands.
* [`src/main.js`](diffhunk://#diff-27653c212e1cfe533e4eb2f7d0d3f89604c9de48a09583b4cbbbcbd08a07da79R54-R56): Stored the original npm registry URL before making changes, ensuring it can be restored after the migration operation.
* [`src/main.js`](diffhunk://#diff-27653c212e1cfe533e4eb2f7d0d3f89604c9de48a09583b4cbbbcbd08a07da79R225-R228): Reset the npm registry to its original value after the migration operation is complete, improving reliability and preventing side effects.…ll reset to the original user registry url (the registry that was used by the user before executing the migration)