### PR TITLE
UPDATE: Version 0.0.7 and github workflow for publishing in the npm r…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to npm
+name: Publish to npm and Github Packages
 
 on:
   push:
@@ -18,12 +18,6 @@ jobs:
         with:
           node-version: "18"
           cache: "npm"
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Configure npm
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
-          echo "always-auth=true" >> ~/.npmrc
 
       - name: Install dependencies
         run: npm install
@@ -31,7 +25,26 @@ jobs:
       - name: Test package
         run: npm run test:coverage
 
+        # --- Publish to GitHub Packages ---
+      - name: Configure npm for GitHub Packages
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > ~/.npmrc
+          echo "always-auth=true" >> ~/.npmrc
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to GitHub Packages
+        run: npm publish --registry=https://npm.pkg.github.com/
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # --- Publish to npm Registry ---
+      - name: Configure npm for npmjs.org
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+          echo "always-auth=true" >> ~/.npmrc
+
       - name: Publish to npm
-        run: npm publish
+        run: npm publish --registry=https://registry.npmjs.org/ --scope=@rawkfx
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 </div>
 
-A command-line tool to migrate npm packages and their dependencies to a local Verdaccio registry without installing
+A command-line tool to migrate npm packages and their dependencies to a local private registry (like Verdaccio) without installing
 them, avoiding dependency conflicts.
 
 ## Installation
@@ -121,7 +121,7 @@ npx migrate-node-deps --requireLogin --username admin --password secret --verbos
 To build and test the library locally, use the following commands:
 
 ```bash
-npm run test # Run tests
+npm run test:coverage # Run tests
 ```
 
 ## License

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "migrate-node-deps",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "migrate-node-deps",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "bin": {
         "migrate-node-deps": "bin/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "migrate-node-deps",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "`migrate-node-deps` is a CLI tool that clones npm dependencies and their transitive dependencies to a local private registry (like Verdaccio).",
   "keywords": [
     "private",


### PR DESCRIPTION
This pull request updates the publishing workflow to support both npm and GitHub Packages, improves documentation, and increments the package version. Below are the most important changes grouped by theme:

### Workflow Enhancements:
* Updated the `.github/workflows/publish.yml` file to publish the package to both npm and GitHub Packages. This includes adding steps to configure npm for GitHub Packages and updating the `npm publish` command to use the appropriate registry for each. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L1-R1) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L21-R48)

### Documentation Improvements:
* Updated the `README.md` to clarify that the tool supports local private registries like Verdaccio instead of only Verdaccio specifically.
* Corrected the test command in the `README.md` from `npm run test` to `npm run test:coverage` to align with the current workflow.

### Version Update:
* Incremented the package version in `package.json` from `0.0.6` to `0.0.7` to reflect the new changes.