### PR TITLE
Update scope of the package.json

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,6 @@ jobs:
           echo "always-auth=true" >> ~/.npmrc
 
       - name: Publish to npm
-        run: npm publish --registry=https://registry.npmjs.org/ --scope=@rawkfx
+        run: npm publish --registry=https://registry.npmjs.org/
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "migrate-node-deps",
+  "name": "@rawkfx/migrate-node-deps",
   "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "migrate-node-deps",
+      "name": "@rawkfx/migrate-node-deps",
       "version": "0.0.7",
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "migrate-node-deps",
+  "name": "@rawkfx/migrate-node-deps",
   "version": "0.0.7",
   "description": "`migrate-node-deps` is a CLI tool that clones npm dependencies and their transitive dependencies to a local private registry (like Verdaccio).",
   "keywords": [


### PR DESCRIPTION
This pull request includes updates to the npm publishing configuration and the `package.json` file to align with the use of a scoped package name. The changes ensure consistency in naming and simplify the publishing process.

### Updates to npm publishing configuration:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L48-R48): Removed the `--scope=@rawkfx` flag from the `npm publish` command, as the scope is now implicitly defined by the package name.

### Updates to package metadata:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L2-R2): Updated the `name` field to use the scoped package name `@rawkfx/migrate-node-deps` to reflect the ownership and namespace of the package.