### PR TITLE
FIX: Removed from github workflow the github packages registry as a p…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to npm and Github Packages
+name: Publish to npm
 
 on:
   push:
@@ -24,19 +24,6 @@ jobs:
 
       - name: Test package
         run: npm run test:coverage
-
-        # --- Publish to GitHub Packages ---
-      - name: Configure npm for GitHub Packages
-        run: |
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > ~/.npmrc
-          echo "always-auth=true" >> ~/.npmrc
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish to GitHub Packages
-        run: npm publish --registry=https://npm.pkg.github.com/
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # --- Publish to npm Registry ---
       - name: Configure npm for npmjs.org

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rawkfx/migrate-node-deps",
+  "name": "migrate-node-deps",
   "version": "0.0.7",
   "description": "`migrate-node-deps` is a CLI tool that clones npm dependencies and their transitive dependencies to a local private registry (like Verdaccio).",
   "keywords": [


### PR DESCRIPTION
This pull request modifies the publishing workflow and package metadata to streamline the deployment process by removing GitHub Packages support and updating the package name.

### Workflow changes:
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L28-L40): Removed steps for publishing to GitHub Packages, including configuring npm for GitHub Packages and the associated `npm publish` command. The workflow now focuses solely on publishing to the npm registry.
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L1-R1): Updated the workflow name from "Publish to npm and Github Packages" to "Publish to npm" to reflect the removal of GitHub Packages support.

### Package metadata changes:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L2-R2): Renamed the package from `@rawkfx/migrate-node-deps` to `migrate-node-deps`, removing the scope prefix.