### PR TITLE
update(publishing): Updated the publishing tag to the private repository

### DIFF
--- a/src/publishToRegistry.js
+++ b/src/publishToRegistry.js
@@ -109,8 +109,8 @@ async function publishToRegistry(packageSpec, options) {
 
                 // Using --access=public to ensure scoped packages publish correctly
                 execSync(`npm publish ${tarballFile} --registry ${defaultRegistry} --access=public --tag ${tag} --provenance=false`, {
-                    stdio: 'pipe',  // Capture output instead of inheriting
-                    timeout: 30000  // 30 seconds timeout
+                    stdio: 'pipe',
+                    timeout: 30000
                 });
 
                 // Clean up tarball file


### PR DESCRIPTION
This pull request makes a minor formatting change to the `publishToRegistry` function in `src/publishToRegistry.js`. The change adjusts the formatting of the `execSync` options for consistency, but does not alter functionality.

Changes:
- Modified (staged): src/publishToRegistry.js\n