### PR TITLE
fix(lockfile): Added the old lockfile reader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "migrate-node-deps",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "migrate-node-deps",
-      "version": "0.1.5",
+      "version": "0.1.7",
       "license": "MIT",
       "bin": {
         "migrate-node-deps": "bin/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "migrate-node-deps",
-  "version": "0.1.6",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "migrate-node-deps",
-      "version": "0.1.6",
+      "version": "0.1.5",
       "license": "MIT",
       "bin": {
         "migrate-node-deps": "bin/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "migrate-node-deps",
-  "version": "0.1.6",
+  "version": "0.1.5",
   "description": "`migrate-node-deps` is a CLI tool that clones npm dependencies and their transitive dependencies to a local private registry (like Verdaccio).",
   "keywords": [
     "private",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "migrate-node-deps",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "description": "`migrate-node-deps` is a CLI tool that clones npm dependencies and their transitive dependencies to a local private registry (like Verdaccio).",
   "keywords": [
     "private",

--- a/src/main.js
+++ b/src/main.js
@@ -80,7 +80,7 @@ async function main() {
         }
 
         // Read package-lock.json
-        const lockFile = JSON.parse(await readFile(config.source));
+        const lockFile = JSON.parse(await readFile(config.lockfilePath, 'utf8'));
 
         // Create temp directory for working
         const tempDir = await mkdtemp(path.join(os.tmpdir(), 'migrate-node-deps-'));


### PR DESCRIPTION
This pull request includes a minor update to the version number in `package.json` and a fix to the way the lockfile is read in `src/main.js`.

- Version bump:
  * Updated the package version from `0.1.6` to `0.1.7` in `package.json`.

- Bug fix:
  * In `src/main.js`, changed the lockfile reading logic to use `config.lockfilePath` and explicitly set the encoding to `'utf8'` for correct file parsing.